### PR TITLE
Introduced release process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,12 @@
 buildscript {
     dependencies {
         classpath 'org.hibernate.build.gradle:gradle-maven-publish-auth:2.0.1'
+        classpath 'net.researchgate:gradle-release:2.8.1'
+
     }
     repositories {
         mavenCentral()
+        jcenter()
     }
 }
 
@@ -16,6 +19,8 @@ subprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'maven-publish-auth'
     apply plugin: "maven"
+    apply plugin: 'signing'
+    apply plugin: 'net.researchgate.release'
 
     repositories {
         mavenCentral()
@@ -70,12 +75,54 @@ subprojects {
                 from components.java
                 artifact sourcesJar
                 artifact javadocJar
+                pom {
+                    name = project.name
+                    description = project.description
+                    url = 'https://github.com/hazelcast/hazelcast-jet-contrib'
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'eminn'
+                            name = 'Emin Demirci'
+                            email = 'emin@hazelcast.com'
+                        }
+                        developer {
+                            id = 'cangencer'
+                            name = 'Can Gencer'
+                            email = 'can@hazelcast.com'
+                        }
+                        developer {
+                            id = 'gurbuzali'
+                            name = 'Ali Gurbuz'
+                            email = 'ali@hazelcast.com'
+                        }
+                        developer {
+                            id = 'jerrinot'
+                            name = 'Jaromir Hamala'
+                            email = 'jaromir@hazelcast.com'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:git://github.com/hazelcast/hazelcast-jet-contrib.git'
+                        developerConnection = 'scm:git:ssh://git@github.com:hazelcast/hazelcast-jet-contrib.git'
+                        url = 'https://github.com/hazelcast/hazelcast-jet-contrib'
+                    }
+                }
             }
         }
         repositories {
             maven {
-                name "snapshot-repository"
-                url "https://oss.sonatype.org/content/repositories/snapshots"
+                def snapshotsRepoName = "snapshot-repository"
+                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+                def releasesRepoName = "release-repository"
+                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                name = version.endsWith('SNAPSHOT') ? snapshotsRepoName : releasesRepoName
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             }
             mavenLocal()
         }
@@ -88,7 +135,39 @@ subprojects {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
 
+    signing {
+        sign publishing.publications.mavenJava
+    }
+
     build.dependsOn javadoc
+
+    release {
+        failOnCommitNeeded = true
+        failOnPublishNeeded = true
+        failOnSnapshotDependencies = true
+        failOnUnversionedFiles = true
+        failOnUpdateNeeded = true
+        revertOnFail = true
+        preCommitText = ''
+        preTagCommitMessage = ''
+        tagCommitMessage = ''
+        newVersionCommitMessage = ''
+        tagTemplate = '${name}-${version}'
+        pushReleaseVersionBranch = false
+        scmAdapters = [
+                net.researchgate.release.GitAdapter
+        ]
+
+        git {
+            requireBranch = 'master'
+            pushToRemote = 'origin'
+            pushToBranchPrefix = ''
+            commitVersionFileOnly = false
+            signTag = false
+        }
+    }
+
+    afterReleaseBuild.dependsOn publish
 
 }
 

--- a/elasticsearch/elasticsearch-5/build.gradle
+++ b/elasticsearch/elasticsearch-5/build.gradle
@@ -1,4 +1,4 @@
-version = '0.1-SNAPSHOT'
+description = 'A Hazelcast Jet connector for Elasticsearch (v5.6.x) for querying/indexing objects from/to Elasticsearch.'
 
 dependencies {
     compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client:5.6.0'

--- a/elasticsearch/elasticsearch-5/gradle.properties
+++ b/elasticsearch/elasticsearch-5/gradle.properties
@@ -1,0 +1,1 @@
+version = 0.1-SNAPSHOT

--- a/elasticsearch/elasticsearch-6/build.gradle
+++ b/elasticsearch/elasticsearch-6/build.gradle
@@ -1,4 +1,4 @@
-version = '0.1-SNAPSHOT'
+description = 'A Hazelcast Jet connector for Elasticsearch (v6.x.x) for querying/indexing objects from/to Elasticsearch.'
 
 dependencies {
     compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client:6.0.0'

--- a/elasticsearch/elasticsearch-6/gradle.properties
+++ b/elasticsearch/elasticsearch-6/gradle.properties
@@ -1,0 +1,1 @@
+version = 0.1-SNAPSHOT

--- a/elasticsearch/elasticsearch-7/build.gradle
+++ b/elasticsearch/elasticsearch-7/build.gradle
@@ -1,4 +1,4 @@
-version = '0.1-SNAPSHOT'
+description = 'A Hazelcast Jet connector for Elasticsearch (v7.x.x) for querying/indexing objects from/to Elasticsearch.'
 
 dependencies {
     compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.0.0'

--- a/elasticsearch/elasticsearch-7/gradle.properties
+++ b/elasticsearch/elasticsearch-7/gradle.properties
@@ -1,0 +1,1 @@
+version = 0.1-SNAPSHOT

--- a/influxdb/build.gradle
+++ b/influxdb/build.gradle
@@ -1,4 +1,4 @@
-version = '0.1-SNAPSHOT'
+description = 'A Hazelcast Jet connector for InfluxDb which enables Hazelcast Jet pipelines to read/write data points from/to InfluxDb.'
 
 dependencies {
     compile 'org.influxdb:influxdb-java:2.15'

--- a/influxdb/gradle.properties
+++ b/influxdb/gradle.properties
@@ -1,0 +1,1 @@
+version = 0.1-SNAPSHOT

--- a/probabilistic/build.gradle
+++ b/probabilistic/build.gradle
@@ -1,1 +1,1 @@
-version = '0.1-SNAPSHOT'
+description = 'Collections of probabilistic aggregations'

--- a/probabilistic/gradle.properties
+++ b/probabilistic/gradle.properties
@@ -1,0 +1,1 @@
+version = 0.1-SNAPSHOT


### PR DESCRIPTION
### What this PR does / why do we need it:
Introduces release plugin for releasing each module independently.

After merging this PR, if we'd like to release influxdb module, for example, running the following command will be enough: 

```
./gradlew :influxdb:release -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=0.1 -Prelease.newVersion=0.2-SNAPSHOT
```

Detailed information on how to configure credentials for release will be explained in the wiki.

#### Which issue this PR fixes
  - N/A

#### Notes to your reviewer:             

#### Checklist

- [x] Signed the Hazelcast CLA
- [x] No checkstyle issues (`./gradlew check`)
- [x] No tests failures (`./gradlew test`)
