### PR TITLE
Fixed swallowed exception when target db is not existing

### DIFF
--- a/influxdb/src/main/java/com/hazelcast/jet/contrib/influxdb/InfluxDbSinks.java
+++ b/influxdb/src/main/java/com/hazelcast/jet/contrib/influxdb/InfluxDbSinks.java
@@ -17,11 +17,14 @@
 package com.hazelcast.jet.contrib.influxdb;
 
 import com.hazelcast.jet.function.SupplierEx;
+import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.SinkBuilder;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.Point;
+
+import static org.influxdb.BatchOptions.DEFAULTS;
 
 /**
  * Contains factory methods for InfluxDB sinks
@@ -53,8 +56,10 @@ public final class InfluxDbSinks {
     public static Sink<Point> influxDb(String url, String database, String username, String password) {
         return influxDb("influxdb-" + database, () ->
                 InfluxDBFactory.connect(url, username, password)
-                        .setDatabase(database)
-                        .enableBatch()
+                               .setDatabase(database)
+                               .enableBatch(
+                                       DEFAULTS.exceptionHandler((points, throwable) -> ExceptionUtil.rethrow(throwable))
+                               )
         );
     }
 }

--- a/influxdb/src/test/java/com/hazelcast/jet/contrib/influxdb/InfluxDbSinkTest.java
+++ b/influxdb/src/test/java/com/hazelcast/jet/contrib/influxdb/InfluxDbSinkTest.java
@@ -29,10 +29,12 @@ import org.influxdb.dto.QueryResult.Series;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.testcontainers.containers.InfluxDBContainer;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 
@@ -50,6 +52,9 @@ public class InfluxDbSinkTest extends JetTestSupport {
             .withDatabase(DATABASE_NAME)
             .withUsername(USERNAME)
             .withPassword(PASSWORD);
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
 
     private JetInstance jet;
 
@@ -87,5 +92,24 @@ public class InfluxDbSinkTest extends JetTestSupport {
         Series series = seriesList.get(0);
         assertEquals(SERIES, series.getName());
         assertEquals(VALUE_COUNT, series.getValues().size());
+    }
+
+    @Test
+    public void test_influxDbSink_nonExistingDb() {
+        IListJet<Integer> measurements = jet.getList("mem_usage");
+        IntStream.range(0, VALUE_COUNT).forEach(measurements::add);
+        influxdbContainer.getNewInfluxDB();
+
+        Pipeline p = Pipeline.create();
+        int startTime = 0;
+        p.drawFrom(Sources.list(measurements))
+         .map(index -> Point.measurement("mem_usage")
+                            .time(startTime + index, TimeUnit.MILLISECONDS)
+                            .addField("value", index)
+                            .build())
+         .drainTo(InfluxDbSinks.influxDb(influxdbContainer.getUrl(), "non-existing", USERNAME, PASSWORD));
+
+        expected.expectMessage("database not found: \"non-existing\"");
+        jet.newJob(p).join();
     }
 }


### PR DESCRIPTION
### What this PR does / why do we need it:
Improves exception handling on InfluxDBSink

#### Which issue this PR fixes
Fixes swallowed exception when target db is not existing

#### Checklist

- [x] Signed the Hazelcast CLA
- [x] No checkstyle issues (`./gradlew check`)
- [x] No tests failures (`./gradlew test`)


