### PR TITLE
Fix constant test failures

### DIFF
--- a/redis/src/main/java/com/hazelcast/jet/contrib/redis/RedisSinks.java
+++ b/redis/src/main/java/com/hazelcast/jet/contrib/redis/RedisSinks.java
@@ -404,7 +404,7 @@ public final class RedisSinks {
 
     private static class SortedSetContext<K, V, T> {
 
-        private static final Duration FLUSH_TIMEOUT = Duration.ofSeconds(1);
+        private static final Duration FLUSH_TIMEOUT = Duration.ofSeconds(10);
 
         private final RedisClient client;
         private final StatefulRedisConnection<K, V> connection;


### PR DESCRIPTION
<!--
Thank you for contributing to hazelcast/hazelcast-jet-contrib. 

Please see contribution guideline beefore you submit this PR:

* https://github.com/hazelcast/hazelcast-jet-contrib/blob/master/CONTRIBUTING.md

Following the guideline will accelerate the review process and help get your 
PR merged quicker.

When updating the PR, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged.

Please make sure you test your changes before you push them. Once pushed, one of
the repository admins will initiate a Jenkins build run across your changes. 
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Which issue this PR fixes
  - increases a flush timeout for Redis Souce Set Sink, which turned out to not be large enough in practice...
 - disables parallel execution of tasks in multiple modules \*

\* It is a bad solution, but I wasn't able to find a way to make only the test tasks serial. This should be a temporary thing until we find a proper solution and I believe it is still better than having all tests fail all the time...

