### PR TITLE
Rely on the GA release of debezium-core

### DIFF
--- a/debezium/build.gradle
+++ b/debezium/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':kafka-connect')
-    compile group: 'io.debezium', name: 'debezium-core', version: '1.0.0.Beta3'
+    compile group: 'io.debezium', name: 'debezium-core', version: '1.0.0.Final'
     testCompile "org.testcontainers:mysql:1.12.3"
     testCompile "org.testcontainers:postgresql:1.12.3"
     testCompile group: 'org.postgresql', name: 'postgresql', version: '42.2.8'


### PR DESCRIPTION
Related to: https://github.com/hazelcast/hazelcast-jet-contrib/pull/34

### What this PR does / why do we need it:

`debezium-core` is already available as `1.0.0.Final`, no need to rely on beta

#### Checklist

- [x] Signed the Hazelcast CLA
- [x] No checkstyle issues (`./gradlew check`)
- [ ] No tests failures (`./gradlew test`)
- [x] Documentation which complies with README template (see `templates/README.template.md`).
- [x] Update `List of modules` section on the root README with your module.

