### PR TITLE
Add ability to finish unstable on jenkins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ subprojects {
     }
 
     test {
+        ignoreFailures = project.findProperty('testFailureIgnore') ? project.testFailureIgnore : false
+
         systemProperty "hazelcast.phone.home.enabled", "false"
         systemProperty "hazelcast.logging.type", "log4j"
 
@@ -80,6 +82,7 @@ subprojects {
     }
 
     task testIntegration(type: Test) {
+        ignoreFailures = project.findProperty('testFailureIgnore') ? project.testFailureIgnore : false
         useJUnit {
             includeCategories 'com.hazelcast.test.annotation.NightlyTest'
         }


### PR DESCRIPTION
### What this PR does / why do we need it:
We add ability to mark build as successful even if there are test failures. This is needed for jenkins job because they can mark build as `UNSTABLE` based on published JUnit reports.

#### Checklist

- [ ] Signed the Hazelcast CLA
- [ ] No checkstyle issues (`./gradlew check`)
- [ ] No tests failures (`./gradlew test`)
- [ ] Documentation which complies with README template (see `templates/README.template.md`).
- [ ] Update `List of modules` section on the root README with your module.

