### PR TITLE
Fix zero-length branch qualifier

### DIFF
--- a/xa-test/README.md
+++ b/xa-test/README.md
@@ -27,14 +27,15 @@ The following brokers were tested by the community:
 |Provider|Result|
 |---|---|
 |**JDBC**||
-|PostgreSQL|OK|
-|H2 Database|Broken|
-|HSQLDB|Broken|
-|MariaDB|Broken|
+|PostgreSQL 12.1|OK|
+|MySQL 8.0|OK|
+|H2 Database 1.4|Broken|
+|HSQLDB 2.4|Broken|
+|MariaDB 10.5|Broken|
 |**JMS**||
-|ActiveMQ|OK|
-|ActiveMQ Artemis|OK|
-|RabbitMQ|no XA support|
+|ActiveMQ 5.15|OK|
+|ActiveMQ Artemis 2.11|OK|
+|RabbitMQ 3.8|no XA support|
 
 
 If you test with another JMS/JDBC provider, a pull request with an

--- a/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/MyXid.java
+++ b/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/MyXid.java
@@ -43,6 +43,6 @@ public final class MyXid implements Xid, Serializable {
 
     @Override
     public byte[] getBranchQualifier() {
-        return new byte[0];
+        return new byte[1];
     }
 }


### PR DESCRIPTION
It's against the standard even though PostgreSQL supports it, MySQL fails with it.
