### PR TITLE
rename config property of spring-boot-starter

### DIFF
--- a/hazelcast-jet-spring-boot-starter/README.md
+++ b/hazelcast-jet-spring-boot-starter/README.md
@@ -39,14 +39,14 @@ You could also specify the Hazelcast Jet server configuration file to
 use through configuration, as shown in the following example:
 
 ```text
-spring.hazelcast.jet.config=classpath:config/my-hazelcast-jet.xml
+hazelcast.jet.config=classpath:config/my-hazelcast-jet.xml
 ```
 
 Or you could specify Hazelcast Jet client configuration as shown in the
 following example:
 
 ```text
-spring.hazelcast.jet.client.config=classpath:config/my-hazelcast-client.xml
+hazelcast.jet.client.config=classpath:config/my-hazelcast-client.xml
 ```
 
 Otherwise, Spring Boot tries to find the Hazelcast Jet configuration
@@ -70,14 +70,14 @@ member will be created).
 * The presence of the `hazelcast.jet.config` system property (a Jet
 member will be created).
 * A configuration file defined by the 
-`configprop:spring.hazelcast.jet.config[]` property (a Jet member will
+`configprop:hazelcast.jet.config[]` property (a Jet member will
  be created).
 * The presence of a `com.hazelcast.client.config.ClientConfig` bean (a
 Jet client will be created).
 * The presence of the `hazelcast.client.config` system property (a Jet
 client will be created).
 * A configuration file defined by the 
-`configprop:spring.hazelcast.jet.client.config[]` property (a Jet
+`configprop:hazelcast.jet.client.config[]` property (a Jet
 client will be created).
 * `hazelcast-jet.yaml`, `hazelcast-jet.yml` or `hazelcast-jet.xml` in
 the working directory or at the root of the classpath. (a Jet member

--- a/hazelcast-jet-spring-boot-starter/src/main/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetClientConfigAvailableCondition.java
+++ b/hazelcast-jet-spring-boot-starter/src/main/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetClientConfigAvailableCondition.java
@@ -18,14 +18,14 @@ package com.hazelcast.jet.contrib.autoconfigure;
 
 /**
  * {@link HazelcastJetConfigResourceCondition} that checks if the
- * {@code spring.hazelcast.jet.config} configuration key is defined.
+ * {@code hazelcast.jet.config} configuration key is defined.
  */
 public class HazelcastJetClientConfigAvailableCondition extends HazelcastJetConfigResourceCondition {
 
     /**
      * Spring property for Hazelcast Jet client configuration
      */
-    public static final String CONFIG_ENVIRONMENT_PROPERTY = "spring.hazelcast.jet.client.config";
+    public static final String CONFIG_ENVIRONMENT_PROPERTY = "hazelcast.jet.client.config";
 
     /**
      * System property for Hazelcast Jet client configuration

--- a/hazelcast-jet-spring-boot-starter/src/main/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetClientProperties.java
+++ b/hazelcast-jet-spring-boot-starter/src/main/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetClientProperties.java
@@ -23,7 +23,7 @@ import org.springframework.util.Assert;
 /**
  * Configuration properties for the hazelcast jet integration.
  */
-@ConfigurationProperties(prefix = "spring.hazelcast.jet.client")
+@ConfigurationProperties(prefix = "hazelcast.jet.client")
 public class HazelcastJetClientProperties {
 
     /**

--- a/hazelcast-jet-spring-boot-starter/src/main/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetConfigAvailableCondition.java
+++ b/hazelcast-jet-spring-boot-starter/src/main/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetConfigAvailableCondition.java
@@ -22,7 +22,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
  * {@link HazelcastJetConfigResourceCondition} that checks if the
- * {@code spring.hazelcast.jet.config} configuration key is defined.
+ * {@code hazelcast.jet.config} configuration key is defined.
  */
 public class HazelcastJetConfigAvailableCondition extends HazelcastJetConfigResourceCondition {
 
@@ -34,7 +34,7 @@ public class HazelcastJetConfigAvailableCondition extends HazelcastJetConfigReso
     /**
      * System property for Hazelcast Jet server configuration
      */
-    public static final String CONFIG_ENVIRONMENT_PROPERTY = "spring.hazelcast.jet.config";
+    public static final String CONFIG_ENVIRONMENT_PROPERTY = "hazelcast.jet.config";
 
     private final HazelcastJetClientConfigAvailableCondition clientConfigAvailableCondition =
             new HazelcastJetClientConfigAvailableCondition();

--- a/hazelcast-jet-spring-boot-starter/src/main/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetProperties.java
+++ b/hazelcast-jet-spring-boot-starter/src/main/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetProperties.java
@@ -23,7 +23,7 @@ import org.springframework.util.Assert;
 /**
  * Configuration properties for the hazelcast jet integration.
  */
-@ConfigurationProperties(prefix = "spring.hazelcast.jet")
+@ConfigurationProperties(prefix = "hazelcast.jet")
 public class HazelcastJetProperties {
 
     /**

--- a/hazelcast-jet-spring-boot-starter/src/test/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetAutoConfigurationClientTests.java
+++ b/hazelcast-jet-spring-boot-starter/src/test/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetAutoConfigurationClientTests.java
@@ -81,7 +81,7 @@ public class HazelcastJetAutoConfigurationClientTests {
     @Test
     public void explicitConfigFileWithXml() {
         this.contextRunner
-                .withPropertyValues("spring.hazelcast.jet.client.config=com/hazelcast/jet/contrib/autoconfigure/"
+                .withPropertyValues("hazelcast.jet.client.config=com/hazelcast/jet/contrib/autoconfigure/"
                         + "hazelcast-jet-client-specific.xml")
                 .run(assertSpecificHazelcastJetClient("explicit-xml"));
     }
@@ -89,7 +89,7 @@ public class HazelcastJetAutoConfigurationClientTests {
     @Test
     public void explicitConfigFileWithYaml() {
         this.contextRunner
-                .withPropertyValues("spring.hazelcast.jet.client.config=com/hazelcast/jet/contrib/autoconfigure/"
+                .withPropertyValues("hazelcast.jet.client.config=com/hazelcast/jet/contrib/autoconfigure/"
                         + "hazelcast-jet-client-specific.yaml")
                 .run(assertSpecificHazelcastJetClient("explicit-yaml"));
     }
@@ -97,7 +97,7 @@ public class HazelcastJetAutoConfigurationClientTests {
     @Test
     public void explicitConfigUrlWithXml() {
         this.contextRunner
-                .withPropertyValues("spring.hazelcast.jet.client.config=classpath:com/hazelcast/jet/contrib/autoconfigure/"
+                .withPropertyValues("hazelcast.jet.client.config=classpath:com/hazelcast/jet/contrib/autoconfigure/"
                         + "hazelcast-jet-client-specific.xml")
                 .run(assertSpecificHazelcastJetClient("explicit-xml"));
     }
@@ -105,14 +105,14 @@ public class HazelcastJetAutoConfigurationClientTests {
     @Test
     public void explicitConfigUrlWithYaml() {
         this.contextRunner
-                .withPropertyValues("spring.hazelcast.jet.client.config=classpath:com/hazelcast/jet/contrib/autoconfigure/"
+                .withPropertyValues("hazelcast.jet.client.config=classpath:com/hazelcast/jet/contrib/autoconfigure/"
                         + "hazelcast-jet-client-specific.yaml")
                 .run(assertSpecificHazelcastJetClient("explicit-yaml"));
     }
 
     @Test
     public void unknownConfigFile() {
-        this.contextRunner.withPropertyValues("spring.hazelcast.jet.client.config=foo/bar/unknown.xml")
+        this.contextRunner.withPropertyValues("hazelcast.jet.client.config=foo/bar/unknown.xml")
                           .run((context) -> assertThat(context).getFailure().isInstanceOf(BeanCreationException.class)
                                                                .hasMessageContaining("foo/bar/unknown.xml"));
     }

--- a/hazelcast-jet-spring-boot-starter/src/test/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetAutoConfigurationServerTests.java
+++ b/hazelcast-jet-spring-boot-starter/src/test/java/com/hazelcast/jet/contrib/autoconfigure/HazelcastJetAutoConfigurationServerTests.java
@@ -66,31 +66,31 @@ public class HazelcastJetAutoConfigurationServerTests {
 
     @Test
     public void explicitConfigFileWithXml() {
-        this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=com/hazelcast/jet/contrib/autoconfigure/"
+        this.contextRunner.withPropertyValues("hazelcast.jet.config=com/hazelcast/jet/contrib/autoconfigure/"
                 + "hazelcast-jet-specific.xml").run(assertSpecificJetServer("xml"));
     }
 
     @Test
     public void explicitConfigFileWithYaml() {
-        this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=com/hazelcast/jet/contrib/autoconfigure/"
+        this.contextRunner.withPropertyValues("hazelcast.jet.config=com/hazelcast/jet/contrib/autoconfigure/"
                 + "hazelcast-jet-specific.yaml").run(assertSpecificJetServer("yaml"));
     }
 
     @Test
     public void explicitConfigUrlWithXml() {
-        this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=classpath:com/hazelcast/jet/contrib/"
+        this.contextRunner.withPropertyValues("hazelcast.jet.config=classpath:com/hazelcast/jet/contrib/"
                 + "autoconfigure/hazelcast-jet-specific.xml").run(assertSpecificJetServer("xml"));
     }
 
     @Test
     public void explicitConfigUrlWithYaml() {
-        this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=classpath:com/hazelcast/jet/contrib/"
+        this.contextRunner.withPropertyValues("hazelcast.jet.config=classpath:com/hazelcast/jet/contrib/"
                 + "autoconfigure/hazelcast-jet-specific.yaml").run(assertSpecificJetServer("yaml"));
     }
 
     @Test
     public void unknownConfigFile() {
-        this.contextRunner.withPropertyValues("spring.hazelcast.jet.config=foo/bar/unknown.xml")
+        this.contextRunner.withPropertyValues("hazelcast.jet.config=foo/bar/unknown.xml")
                           .run((context) -> assertThat(context).getFailure().isInstanceOf(BeanCreationException.class)
                                                                .hasMessageContaining("foo/bar/unknown.xml"));
     }
@@ -98,7 +98,7 @@ public class HazelcastJetAutoConfigurationServerTests {
     @Test
     public void configInstanceWithoutName() {
         this.contextRunner.withUserConfiguration(HazelcastJetConfig.class)
-                          .withPropertyValues("spring.hazelcast.jet.config=this-is-ignored.xml")
+                          .withPropertyValues("hazelcast.jet.config=this-is-ignored.xml")
                           .run(assertSpecificJetServer("configAsBean"));
     }
 


### PR DESCRIPTION
### What this PR does / why do we need it:

Rename config property of spring-boot-starter according to the spring-boot naming conventions
https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-custom-starter-configuration-keys

#### Which issue this PR fixes
  - fixes #62 


- [x] Signed the Hazelcast CLA
- [x] No checkstyle issues (`./gradlew check`)
- [x] No tests failures (`./gradlew test`)
- [x] Documentation which complies with README template (see `templates/README.template.md`).
- [x] Update `List of modules` section on the root README with your module.

