### PR TITLE
Simplify usage of xa-test with example brokers

### DIFF
--- a/xa-test/build.gradle
+++ b/xa-test/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'
     //    Add your broker dependency here, for example:
-    //    implementation 'org.postgresql:postgresql:42.2.9'
-    //    implementation 'org.apache.activemq:activemq-all:5.15.11'
+    //    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.9'
+    //    compile group: 'org.apache.activemq', name:'activemq-all', version:'5.15.11'
 }

--- a/xa-test/build.gradle
+++ b/xa-test/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'
-    //    Add your broker dependency here:
+    //    Add your broker dependency here, for example:
     //    implementation 'org.postgresql:postgresql:42.2.9'
     //    implementation 'org.apache.activemq:activemq-all:5.15.11'
 }

--- a/xa-test/build.gradle
+++ b/xa-test/build.gradle
@@ -1,3 +1,6 @@
 dependencies {
     compile group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'
+    //    Add your broker dependency here:
+    //    implementation 'org.postgresql:postgresql:42.2.9'
+    //    implementation 'org.apache.activemq:activemq-all:5.15.11'
 }

--- a/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JdbcXaTest.java
+++ b/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JdbcXaTest.java
@@ -39,6 +39,7 @@ public final class JdbcXaTest {
      * Configure XADataSource for broker here.
      */
     private static XADataSource getXADataSource() {
+        // Add your datasource here, here is an example for PostgreSQL:
 //        PGXADataSource factory = new PGXADataSource();
 //        factory.setUrl(URL);
 //        factory.setUser(USER);
@@ -55,7 +56,7 @@ public final class JdbcXaTest {
         XADataSource factory = null;
 
         if (factory == null) {
-            throw new IllegalArgumentException("Provide XADataSource for broker in getXADataSource() method");
+            throw new IllegalArgumentException("Provide XADataSource for your broker in the getXADataSource() method");
         }
 
         // create an xa-connection, connection and XA transaction

--- a/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JdbcXaTest.java
+++ b/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JdbcXaTest.java
@@ -53,7 +53,7 @@ public final class JdbcXaTest {
     public static void main(String[] args) throws Exception {
         // replace this line with a factory for your database, for example:
         //    PGXADataSource factory = new PGXADataSource();
-        XADataSource factory = null;
+        XADataSource factory = getXADataSource();
 
         if (factory == null) {
             throw new IllegalArgumentException("Provide XADataSource for your broker in the getXADataSource() method");

--- a/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JdbcXaTest.java
+++ b/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JdbcXaTest.java
@@ -23,22 +23,40 @@ import javax.transaction.xa.Xid;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
+//import org.postgresql.xa.PGXADataSource;
 
 /**
  * Tests if the JDBC database persists a prepared XA transaction when the
  * client disconnects.
  * <p>
- * You need to add your XADataSource to the first line of the main() method.
+ * You need to add your XADataSource to getXADataSource() method.
  */
 public final class JdbcXaTest {
 
     private JdbcXaTest() { }
+
+    /**
+     * Configure XADataSource for broker here.
+     */
+    private static XADataSource getXADataSource() {
+//        PGXADataSource factory = new PGXADataSource();
+//        factory.setUrl(URL);
+//        factory.setUser(USER);
+//        factory.setPassword(PASSWORD);
+//        factory.setDatabaseName(DATABASE_NAME);
+//        return factory;
+        return null;
+    }
 
     /** */
     public static void main(String[] args) throws Exception {
         // replace this line with a factory for your database, for example:
         //    PGXADataSource factory = new PGXADataSource();
         XADataSource factory = null;
+
+        if (factory == null) {
+            throw new IllegalArgumentException("Provide XADataSource for broker in getXADataSource() method");
+        }
 
         // create an xa-connection, connection and XA transaction
         XAConnection xaConn = factory.getXAConnection();

--- a/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JmsXaTest.java
+++ b/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JmsXaTest.java
@@ -53,7 +53,7 @@ public final class JmsXaTest {
         XAConnectionFactory factory = getXAConnectionFactory();
 
         if (factory == null) {
-            throw new IllegalArgumentException("Provide factory for broker in getXAConnectionFactory() method");
+            throw new IllegalArgumentException("Provide a factory for the broker in the getXAConnectionFactory() method");
         }
 
         // create a connection, session and XA transaction

--- a/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JmsXaTest.java
+++ b/xa-test/src/main/java/com/hazelcast/jet/contrib/xatests/JmsXaTest.java
@@ -24,12 +24,13 @@ import javax.jms.XAConnectionFactory;
 import javax.jms.XASession;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
+//import org.apache.activemq.ActiveMQXAConnectionFactory;
 
 /**
  * Tests if the JMS broker persists a prepared XA transaction when the client
  * disconnects.
  * <p>
- * You need to add your XADataSource to the first line of the main() method.
+ * You need to add your XADataSource to getXAConnectionFactory() method.
  */
 public final class JmsXaTest {
 
@@ -37,11 +38,23 @@ public final class JmsXaTest {
 
     private JmsXaTest() { }
 
-    /** */
-    public static void main(String[] args) throws Exception {
+    /**
+     * Configure factory for broker here.
+     */
+    private static XAConnectionFactory getXAConnectionFactory() {
         // replace this line with a factory for your broker, for example:
         //    ActiveMQXAConnectionFactory factory = new ActiveMQXAConnectionFactory(BROKER_URL);
-        XAConnectionFactory factory = null;
+        //    return factory;
+        return null;
+    }
+
+    /** */
+    public static void main(String[] args) throws Exception {
+        XAConnectionFactory factory = getXAConnectionFactory();
+
+        if (factory == null) {
+            throw new IllegalArgumentException("Provide factory for broker in getXAConnectionFactory() method");
+        }
 
         // create a connection, session and XA transaction
         XAConnection conn = factory.createXAConnection();
@@ -79,5 +92,6 @@ public final class JmsXaTest {
         } else {
             System.out.println("Success!");
         }
+        conn.close();
     }
 }


### PR DESCRIPTION
Simplify usage of xa-test with default brokers:
* Added configuration for Postgres for JDBC xa-test
* Added configuration for ActiveMQ for JMS xa-test
* Added missing connection close in JMS xa-test