### PR TITLE
Configure tests jar publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,19 @@ subprojects {
         }
     }
 
+    task testJar(type: Jar) {
+        from sourceSets.test.output.classesDirs
+        archiveClassifier = 'tests'
+    }
+
+    configurations {
+        tests
+        published.extendsFrom tests, archives
+    }
+
+    artifacts {
+        tests testJar
+    }
 
     task sourcesJar(type: Jar) {
         from sourceSets.main.allJava
@@ -102,6 +115,7 @@ subprojects {
                 from components.java
                 artifact sourcesJar
                 artifact javadocJar
+                artifact testJar
                 pom {
                     name = project.name
                     description = project.description


### PR DESCRIPTION
### What this PR does / why do we need it:
It publishes test sources with the `tests` classifier

#### Checklist
- [x] Signed the Hazelcast CLA
- [x] No checkstyle issues (`./gradlew check`)
- [x] No tests failures (`./gradlew test`)
