### PR TITLE
Upgrade Jet version to 4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ subprojects {
     targetCompatibility = '1.8'
 
     ext {
-        jetVersion = '4.1'
-        hazelcastVersion = '4.0.1'
+        jetVersion = '4.2'
+        hazelcastVersion = '4.0.2'
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
 
     ext {
         jetVersion = '4.2'
-        hazelcastVersion = '4.0.2'
+        hazelcastVersion = '4.0.1'
     }
 
     dependencies {


### PR DESCRIPTION
### What this PR does / why do we need it:
Upgrade the version of Jet. Since these versions are backward-compatible, these changes are no effect on modules. I ran the tests and tested the latest release of the pulsar module with Jet 4.2, they worked well.
#### Checklist
- [x] Signed the Hazelcast CLA
- [x] No checkstyle issues (`./gradlew check`)
- [x] No tests failures (`./gradlew test`)
