### PR TITLE
Remove mapping to preserve order

### DIFF
--- a/redis/src/test/java/com/hazelcast/jet/contrib/redis/RedisSourceTest.java
+++ b/redis/src/test/java/com/hazelcast/jet/contrib/redis/RedisSourceTest.java
@@ -124,7 +124,7 @@ public class RedisSourceTest extends JetTestSupport {
         IList<ScoredValue<String>> list = instance.getList("list");
         assertTrueEventually(() -> assertEquals(rangeEnd - rangeStart + 1, list.size()));
         assertEquals(rangeStart, (int) list.get(0).getScore());
-        assertEquals(rangeStart+1000, (int) list.get(1000).getScore());
+        assertEquals(rangeStart + 1000, (int) list.get(1000).getScore());
         assertEquals(rangeEnd, (int) list.get(list.size() - 1).getScore());
     }
 

--- a/redis/src/test/java/com/hazelcast/jet/contrib/redis/RedisSourceTest.java
+++ b/redis/src/test/java/com/hazelcast/jet/contrib/redis/RedisSourceTest.java
@@ -117,15 +117,15 @@ public class RedisSourceTest extends JetTestSupport {
 
         Pipeline p = Pipeline.create();
         p.readFrom(RedisSources.sortedSet("source", uri, "sortedSet", rangeStart, rangeEnd))
-                .map(sv -> (int) sv.getScore() + ":" + sv.getValue())
                 .writeTo(Sinks.list("list"));
 
         instance.newJob(p).join();
 
-        IList<String> list = instance.getList("list");
+        IList<ScoredValue<String>> list = instance.getList("list");
         assertTrueEventually(() -> assertEquals(rangeEnd - rangeStart + 1, list.size()));
-        assertEquals(rangeStart + ":foobar-" + rangeStart , list.get(0));
-        assertEquals(rangeEnd + ":foobar-" + rangeEnd , list.get(list.size() - 1));
+        assertEquals(rangeStart, (int) list.get(0).getScore());
+        assertEquals(rangeStart+1000, (int) list.get(1000).getScore());
+        assertEquals(rangeEnd, (int) list.get(list.size() - 1).getScore());
     }
 
     private void fillSortedSet(String sortedSet, int elementCount) {


### PR DESCRIPTION
### What this PR does / why do we need it:

The PR fixes the Redis Sorted Set test by removing the mapping stage. The mapping stage re-orders the items.

#### Which issue this PR fixes
  - fixes #86 

#### Notes to your reviewer:             


#### Checklist

- [X] Signed the Hazelcast CLA
- [X] No checkstyle issues (`./gradlew check`)
- [X] No tests failures (`./gradlew test`)
- [X] Documentation which complies with README template (see `templates/README.template.md`).
- [X] Update `List of modules` section on the root README with your module.

