### PR TITLE
Use ConcurrentLinkedQueue to buffer the messages

### DIFF
--- a/http/src/main/java/com/hazelcast/jet/contrib/http/HttpListenerSinkBuilder.java
+++ b/http/src/main/java/com/hazelcast/jet/contrib/http/HttpListenerSinkBuilder.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.contrib.http;
 
+import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.internal.util.Preconditions;
@@ -253,7 +254,7 @@ public class HttpListenerSinkBuilder<T> {
                 SinkProcessors.writeBufferedP(ctx -> new HttpListenerSinkContext<>(ctx, path, port,
                                 accumulateLimit, mutualAuthentication, sinkType, sslContextFn, hostFn, toStringFn),
                         HttpListenerSinkContext::receive,
-                        HttpListenerSinkContext::flush,
+                        ConsumerEx.noop(),
                         HttpListenerSinkContext::close
                 );
         String sinkName = sinkType == WEBSOCKET ? websocketName() : serverSentName();

--- a/http/src/main/java/com/hazelcast/jet/contrib/http/impl/HttpListenerSinkContext.java
+++ b/http/src/main/java/com/hazelcast/jet/contrib/http/impl/HttpListenerSinkContext.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.contrib.http.impl;
 
 
+import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.Util;
@@ -51,8 +52,7 @@ public class HttpListenerSinkContext<T> {
     private final Undertow undertow;
     private final FunctionEx<T, String> toStringFn;
     private final Ringbuffer<String> ringBuffer;
-    private final int accumulateLimit;
-    private final ConcurrentLinkedQueue<String> messageBuffer;
+    private final MessageBuffer messageBuffer;
 
     public HttpListenerSinkContext(
             @Nonnull Processor.Context context,
@@ -65,8 +65,8 @@ public class HttpListenerSinkContext<T> {
             @Nonnull SupplierEx<String> hostFn,
             @Nonnull FunctionEx<T, String> toStringFn
     ) {
-        this.accumulateLimit = accumulateLimit;
-        this.messageBuffer = accumulateLimit > 0 ? new ConcurrentLinkedQueue<>() : null;
+        this.messageBuffer = accumulateLimit > 0
+                ? new ConcurrentMessageBuffer(accumulateLimit) : new NoopMessageBuffer();
         this.sinkHttpHandler = sinkType == WEBSOCKET ? new WebSocketSinkHttpHandler(messageBuffer)
                 : new ServerSentSinkHttpHandler(messageBuffer);
         this.toStringFn = toStringFn;
@@ -95,41 +95,18 @@ public class HttpListenerSinkContext<T> {
 
     @SuppressWarnings("unchecked")
     public void receive(Object item) {
+        String itemString = toStringFn.apply((T) item);
         if (sinkHttpHandler.hasConnectedClients()) {
-            drainBuffer();
-            sinkHttpHandler.send(toStringFn.apply((T) item));
+            messageBuffer.drain(sinkHttpHandler::send);
+            sinkHttpHandler.send(itemString);
         } else {
-            putToBuffer((T) item);
-        }
-    }
-
-    public void flush() {
-        if (sinkHttpHandler.hasConnectedClients()) {
-            drainBuffer();
+            messageBuffer.add(itemString);
         }
     }
 
     public void close() {
         undertow.stop();
         ringBuffer.destroy();
-    }
-
-    private void drainBuffer() {
-        if (messageBuffer == null) {
-            return;
-        }
-        String message = messageBuffer.poll();
-        while (message != null) {
-            sinkHttpHandler.send(message);
-            message = messageBuffer.poll();
-        }
-    }
-
-    private void putToBuffer(T item) {
-        if (messageBuffer == null || messageBuffer.size() == accumulateLimit) {
-            return;
-        }
-        messageBuffer.add(toStringFn.apply(item));
     }
 
     interface SinkHttpHandler {
@@ -141,19 +118,56 @@ public class HttpListenerSinkContext<T> {
         boolean hasConnectedClients();
     }
 
+    interface MessageBuffer {
+
+        void drain(ConsumerEx<String> consumer);
+
+        void add(String item);
+    }
+
+    static class ConcurrentMessageBuffer implements MessageBuffer {
+
+        private final ConcurrentLinkedQueue<String> queue;
+        private final int accumulateLimit;
+
+        ConcurrentMessageBuffer(int accumulateLimit) {
+            this.queue = new ConcurrentLinkedQueue<>();
+            this.accumulateLimit = accumulateLimit;
+        }
+
+        @Override
+        public void drain(ConsumerEx<String> consumer) {
+            for (String message; (message = queue.poll()) != null; ) {
+                consumer.accept(message);
+            }
+        }
+
+        @Override
+        public void add(String item) {
+            if (queue.size() == accumulateLimit) {
+                queue.poll();
+            }
+            queue.add(item);
+        }
+    }
+
+    static class NoopMessageBuffer implements MessageBuffer {
+        @Override
+        public void drain(ConsumerEx<String> consumer) {
+        }
+
+        @Override
+        public void add(String item) {
+        }
+    }
+
     static class WebSocketSinkHttpHandler implements SinkHttpHandler {
 
         private final WebSocketProtocolHandshakeHandler handler;
         private final Set<WebSocketChannel> peerConnections;
 
-        WebSocketSinkHttpHandler(ConcurrentLinkedQueue<String> messageBuffer) {
-            handler = Handlers.websocket((exchange, channel) -> {
-                String message = messageBuffer.poll();
-                while (message != null) {
-                    send(message);
-                    message = messageBuffer.poll();
-                }
-            });
+        WebSocketSinkHttpHandler(MessageBuffer messageBuffer) {
+            handler = Handlers.websocket((exchange, channel) -> messageBuffer.drain(this::send));
             peerConnections = handler.getPeerConnections();
         }
 
@@ -178,14 +192,8 @@ public class HttpListenerSinkContext<T> {
         private final ServerSentEventHandler handler;
         private final Set<ServerSentEventConnection> connections;
 
-        ServerSentSinkHttpHandler(ConcurrentLinkedQueue<String> messageBuffer) {
-            handler = Handlers.serverSentEvents((connection, lastEventId) -> {
-                String message = messageBuffer.poll();
-                while (message != null) {
-                    send(message);
-                    message = messageBuffer.poll();
-                }
-            });
+        ServerSentSinkHttpHandler(MessageBuffer messageBuffer) {
+            handler = Handlers.serverSentEvents((connection, lastEventId) -> messageBuffer.drain(this::send));
             connections = handler.getConnections();
         }
 

--- a/http/src/test/java/com/hazelcast/jet/contrib/http/HttpListenerSinkTest.java
+++ b/http/src/test/java/com/hazelcast/jet/contrib/http/HttpListenerSinkTest.java
@@ -96,7 +96,28 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testWebsocket_when_accumulateEnabled() throws Throwable {
+    public void testWebsocket_when_clientConnectsAfterAccumulation() {
+        // Given
+        IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
+        Sink<Object> sink = HttpListenerSinks.builder()
+                .accumulateItems(100)
+                .buildWebsocket();
+        startJob(sourceQueue, sink);
+
+        // when
+        int messageCount = 10;
+        postMessages(sourceQueue, messageCount);
+
+        String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
+        Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
+        receiveFromWebSocket(webSocketAddress, queue);
+
+        // test
+        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+    }
+
+    @Test
+    public void testWebsocket_when_accumulateEnabled() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -119,7 +140,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testWebsocket_when_accumulateEnabledWithSmallNumber() throws Throwable {
+    public void testWebsocket_when_accumulateEnabledWithSmallNumber() {
         // Given
         int queueLimit = 5;
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
@@ -143,7 +164,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testWebsocket_when_accumulateDisabled() throws Throwable {
+    public void testWebsocket_when_accumulateDisabled() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -165,7 +186,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testWebsocket_when_sslEnabled() throws Throwable {
+    public void testWebsocket_when_sslEnabled() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -188,7 +209,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testWebsocket_when_mutualAuthEnabled() throws Throwable {
+    public void testWebsocket_when_mutualAuthEnabled() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -212,7 +233,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testWebsocket_when_portConfigured() throws Throwable {
+    public void testWebsocket_when_portConfigured() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -236,7 +257,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testWebsocket_when_pathConfigured() throws Throwable {
+    public void testWebsocket_when_pathConfigured() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -260,7 +281,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testWebsocket_when_toStringFnConfigured() throws Throwable {
+    public void testWebsocket_when_toStringFnConfigured() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -284,7 +305,29 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testSSE_when_accumulateEnabled() throws Throwable {
+    public void testSSE_when_clientConnectsAfterAccumulation() {
+        // Given
+        IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
+        Sink<Object> sink = HttpListenerSinks.builder()
+                .accumulateItems(100)
+                .buildServerSent();
+        startJob(sourceQueue, sink);
+
+        // when
+        int messageCount = 10;
+
+        postMessages(sourceQueue, messageCount);
+
+        String sseAddress = HttpListenerSinks.sinkAddress(jet, job);
+        Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
+        receiveFromSse(sseAddress, queue);
+
+        // test
+        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+    }
+
+    @Test
+    public void testSSE_when_accumulateEnabled() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -307,7 +350,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testSSE_when_accumulateDisabled() throws Throwable {
+    public void testSSE_when_accumulateDisabled() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -329,7 +372,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testSSE_when_sslEnabled() throws Throwable {
+    public void testSSE_when_sslEnabled() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -352,7 +395,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testSSE_when_mutualAuthEnabled() throws Throwable {
+    public void testSSE_when_mutualAuthEnabled() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -376,7 +419,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testSSE_when_portConfigured() throws Throwable {
+    public void testSSE_when_portConfigured() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -400,7 +443,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testSSE_when_pathConfigured() throws Throwable {
+    public void testSSE_when_pathConfigured() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()
@@ -424,7 +467,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     @Test
-    public void testSSE_when_toStringFnConfigured() throws Throwable {
+    public void testSSE_when_toStringFnConfigured() {
         // Given
         IQueue<String> sourceQueue = jet.getHazelcastInstance().getQueue(randomName());
         Sink<Object> sink = HttpListenerSinks.builder()


### PR DESCRIPTION
Http Listener sink accumulates the messages in an ArrayList
and sends them when a client connects. But this should be
triggered by a new item from the upstream.

By converting the ArrayList to ConcurrentLinkedQueue, it is
now possible to send the accumulated messages from the
thread which accepts the client connections. With this
change we don't need to wait for a new item from upstream
to trigger sending the accumulated messages.

fixes #89


- [X] Signed the Hazelcast CLA
- [X] No checkstyle issues (`./gradlew check`)
- [X] No tests failures (`./gradlew test`)
- [NA] Documentation which complies with README template (see `templates/README.template.md`).
- [NA] Update `List of modules` section on the root README with your module.

