### PR TITLE
Use metrics to assert messages received by HTTP sink

### DIFF
--- a/http/src/test/java/com/hazelcast/jet/contrib/http/HttpListenerSinkTest.java
+++ b/http/src/test/java/com/hazelcast/jet/contrib/http/HttpListenerSinkTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.core.metrics.JobMetrics;
 import com.hazelcast.jet.core.metrics.Measurement;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
@@ -57,6 +58,7 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 
 import static com.hazelcast.jet.core.metrics.MetricNames.RECEIVED_COUNT;
+import static com.hazelcast.jet.core.metrics.MetricTags.SINK;
 import static com.launchdarkly.eventsource.ReadyState.OPEN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -559,8 +561,10 @@ public class HttpListenerSinkTest extends HttpTestBase {
     }
 
     void assertReceivedCountEventually(int expected) {
-        assertTrueEventually(() -> assertEquals(expected,
-                job.getMetrics().get(RECEIVED_COUNT).stream().mapToLong(Measurement::value).sum()));
+        assertTrueEventually(() -> {
+            JobMetrics jobMetrics = job.getMetrics().filter(SINK, "true");
+            assertEquals(expected, jobMetrics.get(RECEIVED_COUNT).stream().mapToLong(Measurement::value).sum());
+        });
     }
 
     static class QueueSourceContext {

--- a/http/src/test/java/com/hazelcast/jet/contrib/http/HttpListenerSinkTest.java
+++ b/http/src/test/java/com/hazelcast/jet/contrib/http/HttpListenerSinkTest.java
@@ -18,8 +18,10 @@ package com.hazelcast.jet.contrib.http;
 
 import com.hazelcast.collection.IQueue;
 import com.hazelcast.jet.Job;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.core.metrics.Measurement;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.SourceBuilder;
@@ -54,6 +56,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 
+import static com.hazelcast.jet.core.metrics.MetricNames.RECEIVED_COUNT;
 import static com.launchdarkly.eventsource.ReadyState.OPEN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -71,7 +74,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
     @Before
     public void setUp() throws Exception {
-        createJetMember();
+        createJetMember(jetConfig());
         Xnio xnio = Xnio.getInstance(HttpListenerSinkTest.class.getClassLoader());
         worker = xnio.createWorker(OptionMap.builder()
                 .set(Options.WORKER_IO_THREADS, 2)
@@ -107,13 +110,14 @@ public class HttpListenerSinkTest extends HttpTestBase {
         // when
         int messageCount = 10;
         postMessages(sourceQueue, messageCount);
+        assertReceivedCountEventually(messageCount);
 
         String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
         receiveFromWebSocket(webSocketAddress, queue);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -128,6 +132,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         // when
         int messageCount = 10;
         postMessages(sourceQueue, messageCount);
+        assertReceivedCountEventually(messageCount);
 
         String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
@@ -135,8 +140,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount * 2, queue));
-
+        assertSizeEventually(messageCount * 2, queue);
     }
 
     @Test
@@ -152,7 +156,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         // when
         int messageCount = 10;
         postMessages(sourceQueue, messageCount);
-
+        assertReceivedCountEventually(messageCount);
 
         String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
@@ -160,7 +164,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount + queueLimit, queue));
+        assertSizeEventually(messageCount + queueLimit, queue);
     }
 
     @Test
@@ -175,6 +179,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         int messageCount = 10;
 
         postMessages(sourceQueue, messageCount);
+        assertReceivedCountEventually(messageCount);
 
         String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
@@ -182,7 +187,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -196,16 +201,13 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
         receiveFromWebSocket(webSocketAddress, queue);
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -220,16 +222,13 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
         receiveFromWebSocket(webSocketAddress, queue);
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -243,9 +242,6 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
         assertTrue(webSocketAddress.endsWith("8091/"));
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
@@ -253,7 +249,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -267,9 +263,6 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
         assertTrue(webSocketAddress.endsWith("/user"));
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
@@ -277,7 +270,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -291,16 +284,13 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String webSocketAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
         receiveFromWebSocket(webSocketAddress, queue);
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
         assertEquals(messageCount, queue.stream().filter(s -> s.startsWith("MESSAGE-")).count());
     }
 
@@ -317,13 +307,14 @@ public class HttpListenerSinkTest extends HttpTestBase {
         int messageCount = 10;
 
         postMessages(sourceQueue, messageCount);
+        assertReceivedCountEventually(messageCount);
 
         String sseAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
         receiveFromSse(sseAddress, queue);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -339,6 +330,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         int messageCount = 10;
 
         postMessages(sourceQueue, messageCount);
+        assertReceivedCountEventually(messageCount);
 
         String sseAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
@@ -346,7 +338,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount * 2, queue));
+        assertSizeEventually(messageCount * 2, queue);
     }
 
     @Test
@@ -361,6 +353,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         int messageCount = 10;
 
         postMessages(sourceQueue, messageCount);
+        assertReceivedCountEventually(messageCount);
 
         String sseAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
@@ -368,7 +361,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -382,16 +375,13 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String sseAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
         receiveFromSse(sseAddress, queue);
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -406,16 +396,13 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String sseAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
         receiveFromSse(sseAddress, queue);
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -429,9 +416,6 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String sseAddress = HttpListenerSinks.sinkAddress(jet, job);
         assertTrue(sseAddress.endsWith("8091/"));
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
@@ -439,7 +423,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -453,9 +437,6 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String sseAddress = HttpListenerSinks.sinkAddress(jet, job);
         assertTrue(sseAddress.endsWith("/user"));
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
@@ -463,7 +444,7 @@ public class HttpListenerSinkTest extends HttpTestBase {
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
     }
 
     @Test
@@ -477,16 +458,13 @@ public class HttpListenerSinkTest extends HttpTestBase {
 
         // when
         int messageCount = 10;
-
-        postMessages(sourceQueue, messageCount);
-
         String sseAddress = HttpListenerSinks.sinkAddress(jet, job);
         Collection<String> queue = new ArrayBlockingQueue<>(messageCount * 2);
         receiveFromSse(sseAddress, queue);
         postMessages(sourceQueue, messageCount);
 
         // test
-        assertTrueEventually(() -> assertSizeEventually(messageCount, queue));
+        assertSizeEventually(messageCount, queue);
         assertEquals(messageCount, queue.stream().filter(s -> s.startsWith("MESSAGE-")).count());
     }
 
@@ -561,8 +539,8 @@ public class HttpListenerSinkTest extends HttpTestBase {
         p.readFrom(queueSource(sourceQueue))
                 .withoutTimestamps()
                 .writeTo(sink);
-
-        job = jet.newJob(p);
+        JobConfig jobConfig = new JobConfig().setName(sourceQueue.getName());
+        job = jet.newJob(p, jobConfig);
         assertJobStatusEventually(job, JobStatus.RUNNING);
     }
 
@@ -578,7 +556,11 @@ public class HttpListenerSinkTest extends HttpTestBase {
         for (int i = 0; i < messageCount; i++) {
             sourceQueue.offer(String.format(pattern, i));
         }
-        assertEqualsEventually(sourceQueue::size, 0);
+    }
+
+    void assertReceivedCountEventually(int expected) {
+        assertTrueEventually(() -> assertEquals(expected,
+                job.getMetrics().get(RECEIVED_COUNT).stream().mapToLong(Measurement::value).sum()));
     }
 
     static class QueueSourceContext {

--- a/http/src/test/java/com/hazelcast/jet/contrib/http/HttpTestBase.java
+++ b/http/src/test/java/com/hazelcast/jet/contrib/http/HttpTestBase.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.contrib.http;
 
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.contrib.http.domain.User;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.json.JsonUtil;
@@ -95,7 +96,7 @@ public class HttpTestBase extends JetTestSupport {
 
     @Before
     public void setup() {
-        jet = createJetMember();
+        jet = createJetMember(jetConfig());
         httpClient = HttpClients.createDefault();
         httpsClient = HttpClients
                 .custom()
@@ -140,5 +141,9 @@ public class HttpTestBase extends JetTestSupport {
             }
         }
         throw new AssertionError("Failed to execute the post");
+    }
+
+    static JetConfig jetConfig() {
+        return new JetConfig().configureHazelcast(config -> config.getMetricsConfig().setCollectionFrequencySeconds(1));
     }
 }


### PR DESCRIPTION
### What this PR does / why do we need it:
We test the `accumulation` feature of the sink by posting some messages before any client connected to the sink and then we connect the client and post some more messages. There is a race between posting the first batch of messages and starting the client so tests fail time to time. 

To fix the race, I've added a check using `JobMetrics#RECEIVE_COUNT`. So after posting the first batch of messages, I verify that the `receivedCount` is equal to the message count and then I start the client.

The PR also simplifies some of the tests by removing the accumulation logic. we already test the logic via dedicated tests, no need to test it with every combination.

#### Checklist

- [x] Signed the Hazelcast CLA
- [x] No checkstyle issues (`./gradlew check`)
- [x] No tests failures (`./gradlew test`)
- [ ] Documentation which complies with README template (see `templates/README.template.md`).
- [ ] Update `List of modules` section on the root README with your module.

